### PR TITLE
Bugfix: lazily fix broken img links

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,11 +124,11 @@
                             <span class="navbar-toggler-icon"></span>
                         </button>
                         <a class="navbar-brand d-block d-lg-none" href="#">
-                            <img loading="lazy" width="455" height="120" src="./files/logo-3.png" alt="" title="logo (3)" srcset="https://productstudio.xyz/hdpunks/wp-content/uploads/2021/06/logo-3.png 455w, https://productstudio.xyz/hdpunks/wp-content/uploads/2021/06/logo-3-300x79.png 300w" sizes="(max-width: 455px) 100vw, 455px" class="wp-image-58">
+                            <img loading="lazy" width="455" height="120" src="./files/logo-3.png" alt="" title="logo (3)" class="wp-image-58">
                         </a>
                         <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
                             <a class="navbar-brand d-none d-lg-block" href="#">
-                                <img loading="lazy" width="455" height="120" src="./files/logo-3.png" alt="" title="logo (3)" srcset="https://productstudio.xyz/hdpunks/wp-content/uploads/2021/06/logo-3.png 455w, https://productstudio.xyz/hdpunks/wp-content/uploads/2021/06/logo-3-300x79.png 300w" sizes="(max-width: 455px) 100vw, 455px" class="wp-image-58">
+                                <img loading="lazy" width="455" height="120" src="./files/logo-3.png" alt="" title="logo (3)" class="wp-image-58">
                             </a>
                             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                                 <li class="nav-item">
@@ -206,8 +206,6 @@
                                                     <span class="et_pb_image_wrap "><img loading="lazy" width="455"
                                                             height="120" src="./files/logo-3.png" alt=""
                                                             title="logo (3)"
-                                                            srcset="https://productstudio.xyz/hdpunks/wp-content/uploads/2021/06/logo-3.png 455w, https://productstudio.xyz/hdpunks/wp-content/uploads/2021/06/logo-3-300x79.png 300w"
-                                                            sizes="(max-width: 455px) 100vw, 455px"
                                                             class="wp-image-58"></span>
                                                 </div>
                                             </div>
@@ -399,7 +397,7 @@
                                             <div class="et_pb_column et_pb_column_1_2 et_pb_column_16 pa-inline-buttons  et_pb_css_mix_blend_mode_passthrough et-last-child">
                                                 <div class="et_pb_module et_pb_blurb et_pb_blurb_1  et_pb_text_align_left  et_pb_blurb_position_left et_pb_bg_layout_light">
                                                     <div class="et_pb_blurb_content">
-                                                        <div class="et_pb_main_blurb_image"><span class="et_pb_image_wrap"><img loading="lazy" width="1000" height="1000" src="./files/9906.png" alt="" srcset="https://productstudio.xyz/hdpunks/wp-content/uploads/2021/06/9906.png 1000w, https://productstudio.xyz/hdpunks/wp-content/uploads/2021/06/9906-980x980.png 980w, https://productstudio.xyz/hdpunks/wp-content/uploads/2021/06/9906-480x480.png 480w" sizes="(min-width: 0px) and (max-width: 480px) 480px, (min-width: 481px) and (max-width: 980px) 980px, (min-width: 981px) 1000px, 100vw" class="et-waypoint et_pb_animation_top et_pb_animation_top_tablet et_pb_animation_top_phone wp-image-37 et-animated"></span>
+                                                        <div class="et_pb_main_blurb_image"><span class="et_pb_image_wrap"><img loading="lazy" width="1000" height="1000" src="./files/9906.png" alt="" class="et-waypoint et_pb_animation_top et_pb_animation_top_tablet et_pb_animation_top_phone wp-image-37 et-animated"></span>
                                                         </div>
                                                         <div class="et_pb_blurb_container">
                                                             <h4 class="et_pb_module_header"><span>Keram Design</span>


### PR DESCRIPTION
- By getting rid of `srcsets` that point to a DNS that is no longer used